### PR TITLE
Adding the full body of the request to the Command type

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - bytestring
   - containers
   - exceptions
+  - HTTP
   - http-types
   - lens
   - lens-aeson
@@ -49,6 +50,8 @@ tests:
     main: Main.hs
     source-dirs: test/
     dependencies:
+      - HTTP
       - linklater
       - tasty
       - tasty-hunit
+      - text

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,10 @@ module Main where
 
 import qualified Data.Map as Map
 
+import Data.Bifunctor (bimap)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Network.HTTP.Base (urlEncodeVars)
 import Network.Linklater.Types
 
 import Test.Tasty
@@ -11,11 +15,11 @@ import Test.Tasty.HUnit
 
 commandOfParamsTest :: Assertion
 commandOfParamsTest =
-  commandOfParams incoming @?= fixture
+  commandOfParams fullBody incoming @?= fixture
   where
     fixture =
-      Right (Command "prove" (User "Knuth") (Channel "C2147483705" "test") (Just "text"))
-    incoming = Map.fromList [
+      Right (Command "prove" (User "Knuth") (Channel "C2147483705" "test") (Just "text") "https://hooks.slack.com/commands/00/B4R" "token=XXXXXXXXXXXXXXXXXX&team_id=T0001&team_domain=example&channel_id=C2147483705&channel_name=test&timestamp=1355517523.000005&user_id=U2147483697&user_name=Knuth&text=text&command=%2Fprove&response_url=https%253A%252F%252Fhooks.slack.com%252Fcommands%252F00%252FB4R")
+    vars = [
         ("token", "XXXXXXXXXXXXXXXXXX")
       , ("team_id", "T0001")
       , ("team_domain", "example")
@@ -26,7 +30,14 @@ commandOfParamsTest =
       , ("user_name", "Knuth")
       , ("text", "text")
       , ("command", "/prove")
+      , ("response_url", "https%3A%2F%2Fhooks.slack.com%2Fcommands%2F00%2FB4R")
       ]
+    fullBody = T.encodeUtf8
+      . T.pack
+      . urlEncodeVars
+      . fmap (bimap T.unpack T.unpack)
+      $ vars
+    incoming = Map.fromList vars
 
 unitTests :: TestTree
 unitTests =


### PR DESCRIPTION
The full original body is required to compute the signature of the command as described [here](https://api.slack.com/docs/verifying-requests-from-slack), but since the body is given by a lazy stream, only one layer of middleware can read it...

This way the user can optionally compute the signature if they want to have some privacy on their slash command.

I also added the response url to the command type just because it would be handy